### PR TITLE
blocks: note this is about regular block, q-block already mandates request-tag

### DIFF
--- a/draft-ietf-core-attacks-on-coap.md
+++ b/draft-ietf-core-attacks-on-coap.md
@@ -580,6 +580,9 @@ configurations. The attacks does not work on TCP with TLS or OSCORE (with
 TLS-like sequence number handling) as in these cases no messages can be
 delivered before the delayed message.
 
+This section primarily concerns itself with the regular block-wise mechanism defined in {{rfc7959}}.
+The special-purpose Q-Block mechanism of {{?rfc9177}}
+already mandates the mitigations that were introduced in {{rfc9175}}.
 
 ### Completing an Operation with an Earlier Final Block {#fragment-earlierfinal}
 


### PR DESCRIPTION
This addresses the "what about q-block" part of #2 (I'm not sure if that's all, will check there).